### PR TITLE
Add max-width to div to prevent overflow

### DIFF
--- a/src/main/resources/jenkins/plugins/displayconsoleoutput/DisplayConsoleOutputAction/floatingBox.jelly
+++ b/src/main/resources/jenkins/plugins/displayconsoleoutput/DisplayConsoleOutputAction/floatingBox.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
     <l:main-panel>
-        <div style="background-color: #eee; overflow-x: auto; padding:10px; margin: 2px; border: 1px solid #777;">
+        <div style="background-color: #eee; overflow-x: auto; padding:10px; margin: 2px; border: 1px solid #777; max-width: 700px;">
             <b><a href="lastBuild/console"><img src="${imagesURL}/24x24/terminal.png" width="24" height="24" /></a>
               <st:nbsp />
               <a href="lastBuild/console">${%Console output} #${action.lastBuildNumber}</a>


### PR DESCRIPTION
Jenkins injects a `<div style='float:right'>` between the `<main-panel>` and `<div>` in this file. For certain jobs in Jenkins 2, this styling causes the console output to overflow the `<main-panel>` and obscure the build history in the `<side-panel>` on the Jenkins job page. Adding a `max-width` to the `<div>` prevents this quirky behavior.